### PR TITLE
Add Visual Studio Code dir and settings to dot files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Use symlinks for the wanted files
 ln -s ~/development/dotfiles/.zshrc ~/.zshrc
 ```
 
+### Visual Studio Code
+
+Once Visual Studio Code is installed remove the original `settings.json` and
+create a symlink to the `settings.json` in the vscode directory.
+
+```
+ln -s ~/development/dotfiles/vscode/settings.json ~/Library/Application\ Support/Code/User/settings.json
+```
+
 ### Git Config
 
 The `.gitconfig.local` file is included by `.gitconfig`. Use it to store user

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,0 +1,27 @@
+{
+    "editor.bracketPairColorization.independentColorPoolPerBracketType": true,
+    "editor.fontSize": 14,
+    "editor.fontFamily": "Hack, Menlo, Monaco, 'Courier New', monospace",
+    "editor.formatOnSave": true,
+    "editor.rulers": [
+        80
+    ],
+    "editor.stickyScroll.enabled": true,
+    "files.insertFinalNewline": true,
+    "vim.insertModeKeyBindings": [
+        {
+            "before": [
+                "j",
+                "k"
+            ],
+            "after": [
+                "<esc>"
+            ]
+        }
+    ],
+    "workbench.colorTheme": "Monokai Pro (Filter Ristretto)",
+    "workbench.iconTheme": "Monokai Pro (Filter Ristretto) Icons",
+    "[json][javascript][typescript]": {
+        "editor.tabSize": 2
+    },
+}


### PR DESCRIPTION
Adds the `settings.json` to a `vscode` directory for symlinking the settings file in Visual Studio Code.

This will make it easier to setup and sync my VSCode settings.